### PR TITLE
added buy product urls in envvars

### DIFF
--- a/src/content/simple/pricing.md
+++ b/src/content/simple/pricing.md
@@ -26,9 +26,7 @@ When you purchase an all-access license, you unlock everything: every component 
 - **No recurring subscriptions or update fees** — Pay once and gain permanent access to all our premium Tailwind CSS resources.
 
 
-
-<a href="https://windstatic.lemonsqueezy.com/buy/9bfc74ed-bb0b-464e-adf1-f6766084dac6" type="submit" class="rounded-lg px-4 py-2 text-sm font-semibold w-auto gap-4 transition-all text-white bg-gradient-to-b from-blue-500 to-blue-600 not-prose hover:to-blue-700 h-10 inline-flex items-center justify-between" aria-label="Get your link"> Get all access for $149
-</a>
+<a href="/api/buy/individual" type="submit" class="rounded-lg px-4 py-2 text-sm font-semibold w-auto gap-4 transition-all text-white bg-gradient-to-b from-blue-500 to-blue-600 not-prose hover:to-blue-700 h-10 inline-flex items-center justify-between" aria-label="Get your link"> Get all access for $149</a>
 ---
 
 ---
@@ -39,8 +37,7 @@ For startup teams and agencies
 - **Same as individual +**  get access to all your team. This tier gives you access to up to 25 people.
 
 
-<a href="https://windstatic.lemonsqueezy.com/buy/9bfc74ed-bb0b-464e-adf1-f6766084dac6" type="submit" class="rounded-lg px-4 py-2 text-sm font-semibold w-auto gap-4 transition-all text-white bg-gradient-to-b from-blue-500 to-blue-600 not-prose hover:to-blue-700 h-10 inline-flex items-center justify-between" aria-label="Get your link"> Get access for your team for $299
-</a>
+<a href="/api/buy/team" type="submit" class="rounded-lg px-4 py-2 text-sm font-semibold w-auto gap-4 transition-all text-white bg-gradient-to-b from-blue-500 to-blue-600 not-prose hover:to-blue-700 h-10 inline-flex items-center justify-between" aria-label="Get your link"> Get access for your team for $299</a>
 
 ---
 

--- a/src/pages/api/auth/signin.ts
+++ b/src/pages/api/auth/signin.ts
@@ -1,6 +1,6 @@
 import type { APIRoute } from "astro";
 import { getAuth } from "firebase-admin/auth";
-import { app } from "../../../firebase/server";
+import { app } from "@/firebase/server";
 
 export const GET: APIRoute = async ({ request, cookies, redirect }) => {
   const auth = getAuth(app);

--- a/src/pages/api/buy/[license].ts
+++ b/src/pages/api/buy/[license].ts
@@ -1,0 +1,17 @@
+import type { APIRoute } from "astro";
+
+const individualLicenseUrl = import.meta.env.PRODUCT_INDIVIDUAL_LICENSE_URL;
+const teamLicenseUrl = import.meta.env.PRODUCT_TEAM_LICENSE_URL;
+
+const fallbackUrl = '/404';
+
+export const GET: APIRoute = async ({ params, redirect }) => {
+  switch (params.license) {
+    case "individual":
+      return redirect(individualLicenseUrl || fallbackUrl)
+    case "team":
+      return redirect(teamLicenseUrl || fallbackUrl)
+    default:
+      return redirect(fallbackUrl)
+  }
+}

--- a/src/pages/pricing.astro
+++ b/src/pages/pricing.astro
@@ -4,5 +4,5 @@ import Pricing from "@/content/simple/pricing.md";
 ---
 
 <SimpleLayout>
-  <Pricing/>
+  <Pricing />
 </SimpleLayout>


### PR DESCRIPTION
## Added product urls as environment vars

For development you need to add the following environment variables to your `.env` file:

```
# Product variables
PRODUCT_INDIVIDUAL_LICENSE_URL="https://windstatic.lemonsqueezy.com/buy/XXXXXX"
PRODUCT_TEAM_LICENSE_URL=""
```

**Replace the lemonsqueezy URL with XXXX with the right one.**


For production, you must add those environment variables through the Netlify admin panel. By now, we can set the testing URLs of Lemon squeezy, so we can make tests of buying with fake cards.

